### PR TITLE
fix typo (from `sourcePreviewNodeOptions` to `sourcePreviewNodesOptio…

### DIFF
--- a/src/MouseBackend.js
+++ b/src/MouseBackend.js
@@ -103,12 +103,12 @@ export default class MouseBackend {
   }
 
   connectDragPreview(sourceId, node, options) {
-    this.sourcePreviewNodeOptions[sourceId] = options
+    this.sourcePreviewNodesOptions[sourceId] = options
     this.sourcePreviewNodes[sourceId] = node
 
     return () => {
       delete this.sourcePreviewNodes[sourceId]
-      delete this.sourcePreviewNodeOptions[sourceId]
+      delete this.sourcePreviewNodesOptions[sourceId]
     }
   }
 


### PR DESCRIPTION
This PR fixes typos in the `connectDragPreview` method.

And thanks for the package, I even cannot calculate how many hours did it save for our team. 