### PR TITLE
Remove react dependency (fix #9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,6 @@
     "url": "https://github.com/zyzo/react-dnd-mouse-backend/issues"
   },
   "homepage": "https://github.com/zyzo/react-dnd-mouse-backend#readme",
-  "dependencies": {
-    "react-dnd": "^2.1.2"
-  },
   "devDependencies": {
     "babel": "^6.5.2",
     "babel-cli": "^6.6.5",


### PR DESCRIPTION
Issue #9 says most of it. Turns out the code doesn't depend on `react-dnd` at all, so the dependency can just be dropped. 