### PR TITLE
Revert 'Prevent click event after item has been dragged' from #7

### DIFF
--- a/src/MouseBackend.js
+++ b/src/MouseBackend.js
@@ -53,8 +53,6 @@ export default class MouseBackend {
       this.handleWindowMoveCapture.bind(this)
     this.handleWindowMoveEndCapture =
       this.handleWindowMoveEndCapture.bind(this)
-    this.handleWindowClick =
-      this.handleWindowClick.bind(this)
     this.handleWindowDragstart =
       this.handleWindowDragstart.bind(this)
   }
@@ -77,8 +75,6 @@ export default class MouseBackend {
       this.handleWindowMoveCapture, true)
     window.addEventListener('mouseup',
       this.handleWindowMoveEndCapture, true)
-    window.addEventListener('click',
-      this.handleWindowClick, true)
     window.addEventListener('dragstart',
       this.handleWindowDragstart, true)
   }
@@ -103,8 +99,6 @@ export default class MouseBackend {
       'mousemove', this.handleWindowMoveCapture, true)
     window.removeEventListener(
       'mouseup', this.handleWindowMoveEndCapture, true)
-    window.removeEventListener(
-      'click', this.handleWindowClick, true)
     window.removeEventListener(
       'dragstart', this.handleWindowDragstart, true)
   }
@@ -208,7 +202,6 @@ export default class MouseBackend {
       this.moveStartSourceIds = null
       return
     }
-    this.preventClick = true
 
     e.preventDefault()
 
@@ -217,11 +210,6 @@ export default class MouseBackend {
     this.uninstallSourceNodeRemovalObserver()
     this.actions.drop()
     this.actions.endDrag()
-  }
-
-  handleWindowClick(e) {
-    if (this.preventClick) e.stopPropagation()
-    this.preventClick = false
   }
 
   // Disable drag on images (Firefox)


### PR DESCRIPTION
#7 includes a flag and handler to ignore the first 'click' event directly after dropping an item.  

It's unclear why this change was needed and it causes unexpected functionality in my application.

In my application, after dragging and dropping an item, my next click on anything within the window is swallowed, the next click after that is registered.

This is because of the `this.preventClick` flag being set to `true` on drag end and subsequently to `false` after a window 'click' event.

@qtsd has already forked and reverted the change, plus some. I've just reverted the click handler addition here. 

In the meantime, until this is merged and released, the last released version `react-dnd-mouse-backend@0.1.2` does not have this 'click-swallowing' behavior.