### PR TITLE
revert: revert disable dragstart event preventDefault (#7)

### DIFF
--- a/src/MouseBackend.js
+++ b/src/MouseBackend.js
@@ -53,8 +53,6 @@ export default class MouseBackend {
       this.handleWindowMoveCapture.bind(this)
     this.handleWindowMoveEndCapture =
       this.handleWindowMoveEndCapture.bind(this)
-    this.handleWindowDragstart =
-      this.handleWindowDragstart.bind(this)
   }
 
   setup() {
@@ -75,8 +73,6 @@ export default class MouseBackend {
       this.handleWindowMoveCapture, true)
     window.addEventListener('mouseup',
       this.handleWindowMoveEndCapture, true)
-    window.addEventListener('dragstart',
-      this.handleWindowDragstart, true)
   }
 
   getSourceClientOffset (sourceId) {
@@ -99,8 +95,6 @@ export default class MouseBackend {
       'mousemove', this.handleWindowMoveCapture, true)
     window.removeEventListener(
       'mouseup', this.handleWindowMoveEndCapture, true)
-    window.removeEventListener(
-      'dragstart', this.handleWindowDragstart, true)
   }
 
   connectDragSource(sourceId, node) {
@@ -210,11 +204,6 @@ export default class MouseBackend {
     this.uninstallSourceNodeRemovalObserver()
     this.actions.drop()
     this.actions.endDrag()
-  }
-
-  // Disable drag on images (Firefox)
-  handleWindowDragstart(e) {
-    e.preventDefault()
   }
 
   installSourceNodeRemovalObserver (node) {


### PR DESCRIPTION
#7 calls event.stopPropagation on `dragstart` window event at capturing phase, which is a totally unintended behaviour for a third-party lib  